### PR TITLE
gtk_widget_get_state is deprecated

### DIFF
--- a/src/idomediaplayermenuitem.c
+++ b/src/idomediaplayermenuitem.c
@@ -81,7 +81,7 @@ ido_media_player_menu_item_draw (GtkWidget *widget,
       int y;
 
       gtk_style_context_get_color (gtk_widget_get_style_context (widget),
-                                   gtk_widget_get_state (widget),
+                                   gtk_widget_get_state_flags (widget),
                                    &color);
 
       gtk_widget_get_allocation (widget, &allocation);


### PR DESCRIPTION
gtk_widget_get_state is even deprecated, and has to be replaced with gtk_widget_get_state_flags. It worked.