### PR TITLE
Travis-ci: added support for ppc64le & excluded archlinux docker job on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 dist: bionic
 language: shell
 os: linux
+
+arch:
+  - amd64
+  - ppc64le
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,7 @@ env:
   - DISTRO="debian:testing"
 #  - DISTRO="fedora:latest"
   - DISTRO="ubuntu:rolling"
+jobs:
+  exclude:
+    - env: DISTRO="archlinux:latest"
+      arch: ppc64le


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture and excluded archlinux DISTRO which is currently unavailable for power support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra