### PR TITLE
Drop local config.h includes

### DIFF
--- a/example/menus.c
+++ b/example/menus.c
@@ -7,7 +7,6 @@
 #include "idoswitchmenuitem.h"
 #include "idousermenuitem.h"
 #include "idoremovablemenuitem.h"
-#include "config.h"
 
 static void
 slider_grabbed (GtkWidget *widget, gpointer user_data)

--- a/src/idoalarmmenuitem.c
+++ b/src/idoalarmmenuitem.c
@@ -18,10 +18,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <gtk/gtk.h>
 
 #include "idoactionhelper.h"

--- a/src/idoappointmentmenuitem.c
+++ b/src/idoappointmentmenuitem.c
@@ -18,10 +18,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <gtk/gtk.h>
 
 #include "idoactionhelper.h"

--- a/src/idobasicmenuitem.c
+++ b/src/idobasicmenuitem.c
@@ -17,10 +17,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <gtk/gtk.h>
 
 #include "idoactionhelper.h"

--- a/src/idocalendarmenuitem.c
+++ b/src/idocalendarmenuitem.c
@@ -26,7 +26,6 @@
 #include <gdk/gdkkeysyms.h>
 #include "idoactionhelper.h"
 #include "idocalendarmenuitem.h"
-#include "config.h"
 
 static void     ido_calendar_menu_item_finalize          (GObject        *item);
 static void     ido_calendar_menu_item_select            (GtkMenuItem    *item);

--- a/src/idoentrymenuitem.c
+++ b/src/idoentrymenuitem.c
@@ -25,7 +25,6 @@
 
 #include <gdk/gdkkeysyms.h>
 #include "idoentrymenuitem.h"
-#include "config.h"
 
 static void     ido_entry_menu_item_finalize          (GObject        *item);
 static void     ido_entry_menu_item_select            (GtkMenuItem        *item);

--- a/src/idolocationmenuitem.c
+++ b/src/idolocationmenuitem.c
@@ -17,10 +17,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <string.h> /* strstr() */
 
 #include <gtk/gtk.h>

--- a/src/idomediaplayermenuitem.c
+++ b/src/idomediaplayermenuitem.c
@@ -19,8 +19,6 @@
  *     Lars Uebernickel <lars.uebernickel@canonical.com>
  */
 
-#include "config.h"
-
 #include "idomediaplayermenuitem.h"
 #include "idoactionhelper.h"
 

--- a/src/idoplaybackmenuitem.c
+++ b/src/idoplaybackmenuitem.c
@@ -20,8 +20,6 @@
  *     Lars Uebernickel <lars.uebernickel@canonical.com>
  */
 
-#include "config.h"
-
 #include "idoplaybackmenuitem.h"
 
 #include <gdk/gdkkeysyms.h>

--- a/src/idorange.c
+++ b/src/idorange.c
@@ -25,7 +25,6 @@
 
 #include "idorange.h"
 #include "idotypebuiltins.h"
-#include "config.h"
 
 typedef struct {
   IdoRangeStyle style;

--- a/src/idoremovablemenuitem.c
+++ b/src/idoremovablemenuitem.c
@@ -17,10 +17,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <gtk/gtk.h>
 
 #include "idoactionhelper.h"

--- a/src/idoscalemenuitem.c
+++ b/src/idoscalemenuitem.c
@@ -23,9 +23,6 @@
  *    Cody Russell <crussell@canonical.com>
  */
 
-#include "config.h"
-
-
 #include <gtk/gtk.h>
 #include "idorange.h"
 #include "idoscalemenuitem.h"

--- a/src/idoswitchmenuitem.c
+++ b/src/idoswitchmenuitem.c
@@ -18,8 +18,6 @@
  * Author: Charles Kerr <charles.kerr@canonical.com>
  */
 
-#include "config.h"
-
 #include "idoswitchmenuitem.h"
 #include "idoactionhelper.h"
 

--- a/src/idotimestampmenuitem.c
+++ b/src/idotimestampmenuitem.c
@@ -18,10 +18,6 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <string.h> /* strstr() */
 
 #include <gtk/gtk.h>

--- a/src/idotimestampmenuitem.c
+++ b/src/idotimestampmenuitem.c
@@ -5,16 +5,16 @@
  *   Charles Kerr <charles.kerr@canonical.com>
  *   Ted Gould <ted@canonical.com>
  *
- * This program is free software: you can redistribute it and/or modify it 
- * under the terms of the GNU General Public License version 3, as published 
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
  * by the Free Software Foundation.
  *
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranties of 
- * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
  * PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along 
+ * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/idousermenuitem.c
+++ b/src/idousermenuitem.c
@@ -19,10 +19,6 @@ You should have received a copy of the GNU General Public License along
 with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef HAVE_CONFIG_H
- #include "config.h"
-#endif
-
 #include <gtk/gtk.h>
 
 #include "idousermenuitem.h"


### PR DESCRIPTION
The generated config.h file is redundant, none of the source files use anything from it. This modification is needed for a cleaner transition to CMake.