### PR TITLE
CMakeLists.txt: Move coverage report generation macro into basefolder…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,15 @@ if (ENABLE_TESTS)
     enable_testing()
     add_subdirectory(example)
     add_subdirectory(tests)
+    # coverage
+    if (ENABLE_COVERAGE)
+        find_package(CoverageReport)
+        ENABLE_COVERAGE_REPORT(
+            TARGETS "ayatana-ido3-0.4"
+            TESTS "gtest-menuitems"
+            FILTER /usr/include ${CMAKE_BINARY_DIR}/*
+        )
+    endif()
 endif()
 
 # Display config info

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,10 +23,3 @@ target_link_libraries("gtest-menuitems"
 )
 add_test("gtest-menuitems" "gtest-menuitems")
 add_dependencies("gtest-menuitems" ayatana-ido3-0.4)
-
-
-# coverage
-if (ENABLE_COVERAGE)
-    find_package(CoverageReport)
-    ENABLE_COVERAGE_REPORT(TARGETS "gtest-menuitems" TESTS "gtest-menuitems")
-endif()


### PR DESCRIPTION
…'s CMakeLists.txt file.

 With the previous approach, only coverage of the tests/ subfolder was reported
 (which always should be 100%). With this change, also coverage of the files
 in src/ is reported.