### PR TITLE
Fix modern GTest & enable tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # Options
 
-option(ENABLE_TESTS "Enable all tests and checks" OFF)
+option(ENABLE_TESTS "Enable all tests and checks" ON)
 option(ENABLE_COVERAGE "Enable coverage reports (includes enabling all tests and checks)" OFF)
 option(ENABLE_WERROR "Treat all build warnings as errors" OFF)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(GMock)
+find_package(GTest REQUIRED)
 
 # gtest-menuitems
 


### PR DESCRIPTION
Here's all I could find in terms of `cmake` and `pkgconfig` in [the Void Linux `gtest` package](https://voidlinux.org/packages/?arch=x86_64&q=gtest):
```
$ xbps-query -Rf gtest-devel | grep -E 'cmake|pkgconfig'
/usr/lib/cmake/GTest/GTestConfig.cmake
/usr/lib/cmake/GTest/GTestConfigVersion.cmake
/usr/lib/cmake/GTest/GTestTargets-none.cmake
/usr/lib/cmake/GTest/GTestTargets.cmake
/usr/lib/pkgconfig/gmock.pc
/usr/lib/pkgconfig/gmock_main.pc
/usr/lib/pkgconfig/gtest.pc
/usr/lib/pkgconfig/gtest_main.pc
```

Perhaps we could add some modern distros (like `debian-unstable`) to CI as well to catch issues like this sooner? I've also enabled the option for building tests by default as I think it simply makes sense; what's the point for including them if they're not being exercised (on various distributions with different configurations) :p