### PR TITLE
cmake: Install library as library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,9 +104,7 @@ target_include_directories("ayatana-ido3-0.4" PUBLIC ${PROJECT_DEPS_INCLUDE_DIRS
 target_include_directories("ayatana-ido3-0.4" PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories("ayatana-ido3-0.4" PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions("ayatana-ido3-0.4" PUBLIC G_LOG_DOMAIN="IDO")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libayatana-ido3-0.4.so" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libayatana-ido3-0.4.so.0" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libayatana-ido3-0.4.so.0.0.0" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
+install(TARGETS "ayatana-ido3-0.4" LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
 
 # AyatanaIdo3-0.4.gir
 


### PR DESCRIPTION
Fedora needs libraries to be executable to extract debug information. Debian does not. The cmake TARGETS installation takes care of this, therefore use it.